### PR TITLE
Move PAT access from query params to HTTP headers

### DIFF
--- a/__tests__/pr.test.js
+++ b/__tests__/pr.test.js
@@ -28,14 +28,14 @@ test('isTooOld returns false if PR was merged within 5 minutes', t => {
 
 test('getReleasesUrl returns the url for the github repo releases endpoint', t => {
   const expected =
-    'https://api.github.com/repos/NYTimes/Chronicler/releases?access_token=MOCK_TOKEN'
+    'https://api.github.com/repos/NYTimes/Chronicler/releases'
 
   t.is(getReleasesUrl(pr), expected)
 })
 
 test('getSingleReleaseUrl returns the github release url for a given release id', t => {
   const expected =
-    'https://api.github.com/repos/NYTimes/Chronicler/releases/9797693?access_token=MOCK_TOKEN'
+    'https://api.github.com/repos/NYTimes/Chronicler/releases/9797693'
 
   t.is(getSingleReleaseUrl(pr, draft), expected)
 })

--- a/src/helpers/pr.js
+++ b/src/helpers/pr.js
@@ -2,8 +2,9 @@ import axios from 'axios'
 import moment from 'moment'
 
 // github needs a user agent in the request, setting as app name
-const userAgent = {
-  'User-Agent': process.env.APP_NAME || 'Chronicler'
+const requestHeaders = {
+  'User-Agent': process.env.APP_NAME || 'Chronicler',
+  'Authorization': `token ${process.env.GH_TOKEN}
 }
 
 /**
@@ -41,7 +42,7 @@ export const getPrData = ({ pull_request, repository }) => ({
  * @returns {String}
  */
 export const getSingleReleaseUrl = (pr, release) =>
-  `${pr.repoUrl}/releases/${release.id}?access_token=${process.env.GH_TOKEN}`
+  `${pr.repoUrl}/releases/${release.id}`
 
 /**
  * Get the releases url for the github repo passed
@@ -118,7 +119,7 @@ export const createReleaseDraft = pr => {
   const options = {
     method: 'POST',
     url: getReleasesUrl(pr),
-    headers: userAgent,
+    headers: requestHeaders,
     data: newRelease
   }
 

--- a/src/helpers/pr.js
+++ b/src/helpers/pr.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 // github needs a user agent in the request, setting as app name
 const requestHeaders = {
   'User-Agent': process.env.APP_NAME || 'Chronicler',
-  'Authorization': `token ${process.env.GH_TOKEN}
+  'Authorization': `token ${process.env.GH_TOKEN}`
 }
 
 /**
@@ -41,17 +41,15 @@ export const getPrData = ({ pull_request, repository }) => ({
  *
  * @returns {String}
  */
-export const getSingleReleaseUrl = (pr, release) =>
-  `${pr.repoUrl}/releases/${release.id}`
+export const getSingleReleaseUrl = (pr, release) => `${pr.repoUrl}/releases/${release.id}`
 
 /**
  * Get the releases url for the github repo passed
- * @param {String} pull_request pull request object
+ * @param {Object} pr pull request object
  *
  * @returns {String}
  */
-export const getReleasesUrl = pr =>
-  `${pr.repoUrl}/releases?access_token=${process.env.GH_TOKEN}`
+export const getReleasesUrl = pr => `${pr.repoUrl}/releases`
 
 /**
  * Get the formatted pull request description to add to the release draft.
@@ -80,7 +78,7 @@ export const editReleaseDraft = (release, pr) => {
   const options = {
     method: 'PATCH',
     url: getSingleReleaseUrl(pr, release),
-    headers: userAgent,
+    headers: requestHeaders,
     data: {
       body: updateReleaseDraft(pr, release) // setting to the updated body with new line
     }
@@ -170,7 +168,7 @@ export const handleWebhookEvent = webhookData => {
     const options = {
       method: 'GET',
       url: getReleasesUrl(pr),
-      headers: userAgent
+      headers: requestHeaders
     }
 
     // make request to releases endpoint


### PR DESCRIPTION
Per https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/, GitHub has deprecated authentication via query param. For PATs, they recommend moving the token to the request header:

> ### Using access_token as a query param
>
> If you're currently making an API call similar to
> 
> `curl "https://api.github.com/user/repos?access_token=my_access_token"`
> 
> Instead, you should send the token in the header:
> 
> `curl -H 'Authorization: token my_access_token' https://api.github.com/user/repos`

**What kind of change does this PR introduce?**

This is a backwards compatible change to remove Chronicler's dependency on a deprecated API.

**Did you add tests for your changes?**

Tests were updated to accommodate the new pattern.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

No documentation changes are needed.
